### PR TITLE
Fix: Roll back previous change for kobo

### DIFF
--- a/paystack.php
+++ b/paystack.php
@@ -283,7 +283,7 @@ class plgVmPaymentPaystack extends vmPSPlugin
             var handler = PaystackPop.setup({
               key: \'' . $paystack_settings['public_key'] . '\',
               email: \'' . $order_info->email . '\',
-              amount: amount * 100,
+              amount: amount,
               currency: \''.$currency_code.'\',
               ref: \'' . $dbValues['paystack_transaction_reference'] . '\',
               callback: function(response){


### PR DESCRIPTION
#9 was made in error. Correct kobo amount was being passed.